### PR TITLE
script type

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
   <title>Client-side TTT</title>
   <meta name="description" content="TTT">
   <meta name="author" content="Ehawk Graziano">
-  <script src="src/js/scripts.js"></script>
+  <script type="text/javascript" src="src/js/scripts.js"></script>
   <link rel="stylesheet" href="src/css/styles.css">
 </head>
 <body id="body"></body>


### PR DESCRIPTION
generally good code

i added type="text/javascript" to the script tag because that didn't become default until html5, and some browsers still in service, particularly on phones, won't do that

without that those older phones won't run the script because back then we were still pretending other languages might emerge